### PR TITLE
deprecate cluster-namespace option from the appmgr pod

### DIFF
--- a/helm-charts/application-manager/templates/deployment.yaml
+++ b/helm-charts/application-manager/templates/deployment.yaml
@@ -84,7 +84,6 @@ spec:
         args:
           - "--alsologtostderr"
           - "--cluster-name={{ .Values.clusterName }}"
-          - "--cluster-namespace={{ .Values.clusterNamespace }}"
           - "--hub-cluster-configfile=/var/run/klusterlet/kubeconfig"
         livenessProbe:
           exec:


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

The "--cluster-namespace" option has been deprecated since 2.5