### PR TITLE
Remove condition on configmap permissions

### DIFF
--- a/helm-charts/iam-policy-controller/templates/leader_election_role.yaml
+++ b/helm-charts/iam-policy-controller/templates/leader_election_role.yaml
@@ -10,7 +10,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 rules:
-{{- if semverCompare "< 1.14.0" .Capabilities.KubeVersion.Version }}
 - apiGroups:
   - ""
   resources:
@@ -23,7 +22,6 @@ rules:
   - update
   - patch
   - delete
-{{- else }}
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -43,4 +41,3 @@ rules:
   verbs:
   - create
   - patch
-{{- end }}


### PR DESCRIPTION
Since the default leader election resource lock is "configmapsleases",
which uses both resources, the permissions for configmaps is needed for
any cluster, not just OCP 3.11 clusters.

See https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/manager#Options.LeaderElectionResourceLock

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>